### PR TITLE
Windows

### DIFF
--- a/POVRayRender/Documentation/English/ReferencePages/Symbols/ToPOVRayScene.nb
+++ b/POVRayRender/Documentation/English/ReferencePages/Symbols/ToPOVRayScene.nb
@@ -1680,7 +1680,7 @@ Cell[BoxData[
   RowBox[{
    RowBox[{"Run", "[", 
     RowBox[{
-    "POVRayRender`Private`$POVRayPath", "<>", "\"\< \>\"", "<>", "scencePath",
+    "\"\\\"\"", "<>", "POVRayRender`Private`$POVRayPath", "<>", "\"\\\"\< \>\"", "<>", "scencePath",
       "<>", "\"\< +W800 +H600 -J +A0.001\>\""}], "]"}], ";"}], "//", 
   "AbsoluteTiming"}]], "Input",
  CellLabel->"In[12]:=",

--- a/POVRayRender/POVRayRender.m
+++ b/POVRayRender/POVRayRender.m
@@ -1,3 +1,5 @@
+(* ::Package:: *)
+
 (* Mathematica Package *)
 (* Created by Mathematica Plugin for IntelliJ IDEA *)
 
@@ -181,7 +183,7 @@ generatePovrayStringUsingMesh[p_Graphics3D]:=Module[{gc,camera},
 ];
 
 povrayExec[inputPath_,outputPath_,povpath_,povrayOptions_]:=Module[{renderCmd},
-  renderCmd=povpath<>" "<>povrayOptions<>""<>outputPath<>" "<>inputPath;
+  renderCmd="\""<>povpath<>"\" "<>povrayOptions<>""<>outputPath<>" "<>inputPath;
   Run[renderCmd]
 ];
 (* call povray exectuable to render the graphics *)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Installation
 
 Copy the POVRayRender folder to your `$UserBaseDirectory`. 
 
-> On Windows system should be this directory ```FileNameJoin[{$InstallationDirectory, "AddOns/ExtraPackages"}]```
+> On Windows system should be this directory ```FileNameJoin[{$InstallationDirectory, "AddOns/Packages"}]```
 
 
 Usage

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Installation
 
 Copy the POVRayRender folder to your `$UserBaseDirectory`. 
 
+> On Windows system should be this directory ```FileNameJoin[{$InstallationDirectory, "AddOns/ExtraPackages"}]```
+
 
 Usage
 -----


### PR DESCRIPTION
## Fixed the path error, when the `povpath` contain one or more space characters.
- POVRayRender/Documentation/English/ReferencePages/Symbols/ToPOVRayScene.nb
- POVRayRender/POVRayRender.m


## Modified installation directory on windows.
- README.md
But the documentation is  not worded well on windows, and I don't know how to fix it.
**The bug is like the following pictures, hope you can have a look and fix it. Thanks!**
![image](https://user-images.githubusercontent.com/12002827/28996068-ee80f8c8-7a2a-11e7-969f-0998e97e4401.png)
